### PR TITLE
broken-symlink-fix

### DIFF
--- a/book/src/main/scalatex/book/handson/PublishingModules.scalatex
+++ b/book/src/main/scalatex/book/handson/PublishingModules.scalatex
@@ -23,10 +23,10 @@
     │   └── src/main/scala/simple/Platform.scala
     └── project/ build.sbt
   @p
-    In this case the two @code{shared/} folders are symlinked together to keep them in sync. This can be done by first creating @code{js/shared}, and then running
+    In this case the two @code{shared/} folders are symlinked together to keep them in sync. This can be done by first creating @code{js/shared}, and from @code{jvm} then running
 
   @hl.bash
-    $ ln -s ../js/shared jvm/shared
+    $ ln -s ../js/shared/ shared
 
   @sect{Build Configuration}
     @p


### PR DESCRIPTION
Hi,

I'm not sure whether the symlink behavior differs between OS X and Linux, but you need to be in the target directory to create a relative symlink to a directory on Linux ... In case it is not the same on Mac, ignore this PR.
