### PR TITLE
Add link to Greenlight

### DIFF
--- a/book/src/main/scalatex/book/handson/PublishingModules.scalatex
+++ b/book/src/main/scalatex/book/handson/PublishingModules.scalatex
@@ -140,6 +140,8 @@
       @lnk("zCheck", "https://github.com/InTheNow/zcheck")
     @li
       @lnk("oTest", "https://github.com/cgta/otest")
+    @li
+      @lnk("Greenlight", "https://github.com/greencatsoft/greenlight")
 
   @p
     These (and others) are built and maintained by members of the community, so if one of them does not fit your tastes, it is worth trying the others.


### PR DESCRIPTION
Add Greenlight to the list of community maintained test frameworks.