### PR TITLE
Fixed js filename

### DIFF
--- a/examples/crossBuilds/clientserver/app/jvm/src/main/scala/simple/Page.scala
+++ b/examples/crossBuilds/clientserver/app/jvm/src/main/scala/simple/Page.scala
@@ -7,7 +7,7 @@ object Page{
   val skeleton =
     html(
       head(
-        script(src:="/appjs-fastopt.js"),
+        script(src:="/app-fastopt.js"),
         link(
           rel:="stylesheet",
           href:="https://cdnjs.cloudflare.com/ajax/libs/pure/0.5.0/pure-min.css"

--- a/examples/crossBuilds/clientserver2/app/jvm/src/main/scala/simple/Page.scala
+++ b/examples/crossBuilds/clientserver2/app/jvm/src/main/scala/simple/Page.scala
@@ -7,7 +7,7 @@ object Page{
   val skeleton =
     html(
       head(
-        script(src:="/appjs-fastopt.js"),
+        script(src:="/app-fastopt.js"),
         link(
           rel:="stylesheet",
           href:="http://yui.yahooapis.com/pure/0.5.0/pure-min.css"


### PR DESCRIPTION
Hi,
A pull request to be able to run the examples stand-alone using sbt again.
Looks like the the the ScalaJS plugin changed the name of the generated Javascript file from 0.6 to 0.6.1.