### PR TITLE
Updated comment about async in scala.js prior to 0.6.0 to clarify

### DIFF
--- a/examples/demos/src/main/scala/advanced/Async.scala
+++ b/examples/demos/src/main/scala/advanced/Async.scala
@@ -36,7 +36,8 @@ object Async {
     val mousedown =
       new Channel[ME](canvas.onmousedown = _)
 
-    // Disabled due to scala-js#1469
+    // async was disabled prior to Scala.js 0.6.0
+    // due to issue scala-js#1469
     async{
       while(true){
         val start = await(mousedown())


### PR DESCRIPTION
The current document creates the impression that async is still disabled in scala.js. I modified the code comment to clarify it was fixed in version 0.6.0.