### PR TITLE
Format clock numbers to is always 2 positions

### DIFF
--- a/examples/demos/src/main/scala/canvasapp/Clock.scala
+++ b/examples/demos/src/main/scala/canvasapp/Clock.scala
@@ -29,6 +29,10 @@ object Clock extends{
     renderer.textBaseline = "middle"
 
     /*code*/
+    // format the number with size 2 and optional '0' prefix
+    // so '1' becomes '01'
+    def format(n: Int) = f"$n%02d"
+    
     def render() = {
       val date = new js.Date()
       renderer.clearRect(
@@ -41,7 +45,7 @@ object Clock extends{
           date.getHours(),
           date.getMinutes(),
           date.getSeconds()
-        ).mkString(":"),
+        ).map(format).mkString(":"),
         canvas.width / 2,
         canvas.height / 2
       )


### PR DESCRIPTION
Now n < 10 get prefixed with '0'.
Whereas before a time would be displayed as '1:2:3', it is now shown as '01:02:03'.
It also nicely demonstrates how you can still use Scala collection api methods like 'map'.