### PR TITLE
Remove paragraph referring to `workspace` settings that are not present

### DIFF
--- a/book/src/main/scalatex/handson/GettingStarted.scalatex
+++ b/book/src/main/scalatex/handson/GettingStarted.scalatex
@@ -178,9 +178,6 @@
     @p
       Of interest is the @hl.scala{libraryDependencies}. In Scala-JVM, this key is used to declare dependencies on libraries from Maven Central, so you can use them in your Scala-JVM projects. In Scala.js, the same key is used to declare dependencies on libraries so you can use them in your Scala.js projects! Re-usable libraries can be built and published with Scala.js just as you do on Scala-JVM, and here we make use of one which provides the typed facades with which we used to access the DOM in the application code.
 
-    @p
-      Lastly, we have two Workbench related settings: @hl.scala{bootSnippet} basically tells Workbench how to restart your application when a new compilation run finishes, and @hl.scala{updateBrowsers} actually tells it to perform this application-restarting.
-
   @sect{src/main/resources/index-dev.html}
     @hl.ref(cloneRoot/"workbench-example-app"/'src/'main/'resources/"index-dev.html")
 


### PR DESCRIPTION
This paragraph references sbt configuration that is not present in the current version of the code.  As such, it creates confusion for readers.

If it is instead desirable that the paragraph remains, the settings it mentions should be added to `build.sbt`